### PR TITLE
Crude sanitizer for index values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@
 *.o
 *.a
 mkmf.log
+
+.DS_Store

--- a/lib/activerecord-mysql-structure/active_record/structure_sql_sanitizer.rb
+++ b/lib/activerecord-mysql-structure/active_record/structure_sql_sanitizer.rb
@@ -5,32 +5,68 @@ module ActiveRecordMySqlStructure
   class StructureSqlSanitizer
     COLUMN_REGEX = /\A\s*`\w+`/
 
+    # Naive index check. Covers the most common use-cases
+    INDEX_REGEX = /(?<key_definition>\A\s*(?:UNIQUE )?KEY\s+.*?)(?:,?)(?<after_optional_comma>\s*\Z)/
+
+    # Index sanitization currently assumes that each table's engine has a default of USING BTREE;
+    # crash if any other engine is in use
+    UNSUPPORTED_ENGINE_REGEX = /ENGINE=(?!InnoDB|MyISAM)/
+
+    # Friendly comment warning maintainers that this gem is meddling with the
+    # contents of their structure.sql
+    DECLARATION_OF_ORIGIN = "-- MySQL Dump modified by gem 'activerecord-mysql-structure'"
+
     # When set to true, the sanitizer will sort the columns of each table. This
     # will help keep a consistent column order in the outputted structure file.
     # The columns will be sorted alphabetically.
+    #
+    # @param val [Boolean] the new setting for column sorting
     def self.sorted_columns=(val)
       @sorted_columns = val
     end
 
     # Returns whether the structure should have alphabetically sorted columns.
+    #
+    # @return [Boolean] the current setting for column sorting
     def self.sorted_columns?
       @sorted_columns
     end
 
-    def self.sanitize(filename)
-      new(filename, sorted_columns: sorted_columns?).sanitize!
+    # When set to true, the sanitizer will sort the index definitions of each
+    # table. This will help keep a consistent index order in the outputted
+    # structure file. The indices will be sorted alphabetically, and redundant
+    # index_type clauses will be stripped
+    #
+    # @param val [Boolean] the new setting for index sorting
+    def self.sorted_indices=(val)
+      @sorted_indices = val
     end
 
-    attr_reader :filename, :sorted_columns
+    # Returns whether the structure should have sanitized, alphabetically sorted
+    # indices
+    #
+    # @return [Boolean] the current setting for index sorting
+    def self.sorted_indices?
+      !!@sorted_indices
+    end
 
-    def initialize(filename, sorted_columns:)
+    def self.sanitize(filename)
+      new(filename, sorted_columns: sorted_columns?, sorted_indices: sorted_indices?).sanitize!
+    end
+
+    attr_reader :filename, :sorted_columns, :sorted_indices
+
+    def initialize(filename, sorted_columns:, sorted_indices:)
       @filename = filename
       @sorted_columns = sorted_columns
+      @sorted_indices = sorted_indices
     end
 
     def sanitize!
       lines = load_file
+      lines.unshift(DECLARATION_OF_ORIGIN)
       lines = sort_columns(lines) if sorted_columns
+      lines = sort_indices(lines) if sorted_indices
       lines = lines.join
 
       # remove empty lines from the top using lstrip.
@@ -82,6 +118,37 @@ module ActiveRecordMySqlStructure
 
         # We know we are parsing a table.
         on_table = true if line.include?('CREATE TABLE')
+      end
+
+      sorted_lines
+    end
+
+    def sort_indices(lines)
+      indices = []
+      sorted_lines = []
+
+      lines.each do |line|
+        if UNSUPPORTED_ENGINE_REGEX.match?(line)
+          raise 'MySQL Structure Sanitizer detected an unsupported engine; aborting'
+        end
+
+        match = INDEX_REGEX.match(line)
+        if match
+          # Ensure trailing commas on each line
+          sanitized_index = "#{match[:key_definition]},#{match[:after_optional_comma]}"
+          # Remove redundant, noisy default index type specifier
+          # TODO: this is not safe on tables using the Memory/Heap nor NDB engines
+          indices << sanitized_index.gsub(" USING BTREE", '')
+        else
+          if indices.size > 0
+            sorted_lines += indices.sort
+            # Remove the last trailing comma after the sort completes
+            sorted_lines[-1] = sorted_lines[-1].gsub(/,(?=\s*\Z)/, '')
+            indices.clear
+          end
+
+          sorted_lines << line
+        end
       end
 
       sorted_lines

--- a/spec/activerecord/mysql/structure_spec.rb
+++ b/spec/activerecord/mysql/structure_spec.rb
@@ -22,13 +22,51 @@ describe ActiveRecord::Mysql::Structure do
 
       context 'with sorted columns enabled' do
         subject do
-          ActiveRecordMySqlStructure::StructureSqlSanitizer.new(filename, sorted_columns: true)
+          ActiveRecordMySqlStructure::StructureSqlSanitizer.new(
+            filename,
+            sorted_columns: true,
+            sorted_indices: false
+          )
         end
 
         let(:expected_filename) { File.join(RSpec::root, 'data', 'structure.sorted_columns.sql') }
 
         it 'should remove unwanted lines and substrings from structure.sql' do
           expect(subject.sanitize!).to eq(expected_sanitized_content)
+        end
+      end
+
+      context 'with sorted indices enabled' do
+        subject do
+          ActiveRecordMySqlStructure::StructureSqlSanitizer.new(
+            filename,
+            sorted_columns: false,
+            sorted_indices: true
+          )
+        end
+
+        let(:expected_filename) { File.join(RSpec.root, 'data', 'structure.sorted_indices.sql') }
+
+        it 'sorts and sanitizes the indices' do
+          expect(subject.sanitize!).to eq(expected_sanitized_content)
+        end
+
+        context 'with complex indices' do
+          let(:filename) { File.join(RSpec.root, %w[data structure.complex-indices-example.sql]) }
+          let(:expected_filename) { File.join(RSpec.root, %w[data structure.complex-indices-expected.sql]) }
+
+          it 'sorts and sanitizes the indices' do
+            expect(subject.sanitize!).to eq(expected_sanitized_content)
+          end
+        end
+
+        context 'with an unsupported table engine' do
+          let(:filename) { File.join(RSpec.root, %w[data structure.unsupported-engine-example.sql]) }
+          it "raises an explicit error instead of silently stripping index types" do
+            expect do
+              subject.sanitize!
+            end.to raise_error(RuntimeError)
+          end
         end
       end
     end

--- a/spec/data/structure.complex-indices-example.sql
+++ b/spec/data/structure.complex-indices-example.sql
@@ -1,17 +1,27 @@
--- MySQL Dump modified by gem 'activerecord-mysql-structure'
+--
+-- MySQL dump 10.13  Distrib 5.5.44, for osx10.11 (x86_64)
+--
+-- Host: localhost    Database: development
+-- ------------------------------------------------------
+-- Server version 5.5.44
 
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!40101 SET NAMES utf8mb4 */;
+/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+/*!40103 SET TIME_ZONE='+00:00' */;
+/*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
+/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
+/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
 
-DROP TABLE IF EXISTS `classified_types`;
-CREATE TABLE `classified_types` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
-  `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `created_at` datetime DEFAULT NULL,
-  `updated_at` datetime DEFAULT NULL,
-  PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
-
+-- Table structure for table `classifieds`
+--
 
 DROP TABLE IF EXISTS `classifieds`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `classifieds` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `title` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
@@ -26,31 +36,36 @@ CREATE TABLE `classifieds` (
   `item_img_file_size` int(11) DEFAULT NULL,
   `item_img_updated_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`),
+  UNIQUE KEY `arbitrary_index_name` (`employee_id`, `classified_type_id`) USING BTREE,
   KEY `index_classifieds_on_employee_id` (`employee_id`),
-  KEY `index_classifieds_on_classified_type_id` (`classified_type_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+  KEY `index_classifieds_on_classified_type_id` (`classified_type_id`) USING BTREE
+) ENGINE=InnoDB AUTO_INCREMENT=9 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
 
+--
+-- Table structure for table `schema_migrations`
+--
 
 DROP TABLE IF EXISTS `schema_migrations`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `schema_migrations` (
   `version` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
   UNIQUE KEY `unique_schema_migrations` (`version`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
+/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
+/*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
+/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
-DROP TABLE IF EXISTS `teams`;
-CREATE TABLE `teams` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
-  `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `created_at` datetime NOT NULL,
-  `updated_at` datetime NOT NULL,
-  `email` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `description` text COLLATE utf8_unicode_ci,
-  PRIMARY KEY (`id`),
-  KEY `index_teams_on_name` (`name`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
-
-
+-- Dump completed on 2016-06-02 13:55:23
 INSERT INTO schema_migrations (version) VALUES ('20150213221911');
 
 INSERT INTO schema_migrations (version) VALUES ('20150213222926');
@@ -94,3 +109,4 @@ INSERT INTO schema_migrations (version) VALUES ('20150612181455');
 INSERT INTO schema_migrations (version) VALUES ('20150612232043');
 
 INSERT INTO schema_migrations (version) VALUES ('20160424213633');
+

--- a/spec/data/structure.complex-indices-expected.sql
+++ b/spec/data/structure.complex-indices-expected.sql
@@ -1,16 +1,6 @@
 -- MySQL Dump modified by gem 'activerecord-mysql-structure'
 
 
-DROP TABLE IF EXISTS `classified_types`;
-CREATE TABLE `classified_types` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
-  `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `created_at` datetime DEFAULT NULL,
-  `updated_at` datetime DEFAULT NULL,
-  PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
-
-
 DROP TABLE IF EXISTS `classifieds`;
 CREATE TABLE `classifieds` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -26,8 +16,9 @@ CREATE TABLE `classifieds` (
   `item_img_file_size` int(11) DEFAULT NULL,
   `item_img_updated_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`),
+  KEY `index_classifieds_on_classified_type_id` (`classified_type_id`),
   KEY `index_classifieds_on_employee_id` (`employee_id`),
-  KEY `index_classifieds_on_classified_type_id` (`classified_type_id`)
+  UNIQUE KEY `arbitrary_index_name` (`employee_id`, `classified_type_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 
@@ -35,19 +26,6 @@ DROP TABLE IF EXISTS `schema_migrations`;
 CREATE TABLE `schema_migrations` (
   `version` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
   UNIQUE KEY `unique_schema_migrations` (`version`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
-
-
-DROP TABLE IF EXISTS `teams`;
-CREATE TABLE `teams` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
-  `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `created_at` datetime NOT NULL,
-  `updated_at` datetime NOT NULL,
-  `email` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `description` text COLLATE utf8_unicode_ci,
-  PRIMARY KEY (`id`),
-  KEY `index_teams_on_name` (`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 

--- a/spec/data/structure.sorted_columns.sql
+++ b/spec/data/structure.sorted_columns.sql
@@ -1,3 +1,6 @@
+-- MySQL Dump modified by gem 'activerecord-mysql-structure'
+
+
 DROP TABLE IF EXISTS `classified_types`;
 CREATE TABLE `classified_types` (
   `created_at` datetime DEFAULT NULL,

--- a/spec/data/structure.sorted_indices.sql
+++ b/spec/data/structure.sorted_indices.sql
@@ -26,8 +26,8 @@ CREATE TABLE `classifieds` (
   `item_img_file_size` int(11) DEFAULT NULL,
   `item_img_updated_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`),
-  KEY `index_classifieds_on_employee_id` (`employee_id`),
-  KEY `index_classifieds_on_classified_type_id` (`classified_type_id`)
+  KEY `index_classifieds_on_classified_type_id` (`classified_type_id`),
+  KEY `index_classifieds_on_employee_id` (`employee_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 

--- a/spec/data/structure.unsupported-engine-example.sql
+++ b/spec/data/structure.unsupported-engine-example.sql
@@ -1,17 +1,27 @@
--- MySQL Dump modified by gem 'activerecord-mysql-structure'
+--
+-- MySQL dump 10.13  Distrib 5.5.44, for osx10.11 (x86_64)
+--
+-- Host: localhost    Database: development
+-- ------------------------------------------------------
+-- Server version 5.5.44
 
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!40101 SET NAMES utf8mb4 */;
+/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+/*!40103 SET TIME_ZONE='+00:00' */;
+/*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
+/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
+/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
 
-DROP TABLE IF EXISTS `classified_types`;
-CREATE TABLE `classified_types` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
-  `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `created_at` datetime DEFAULT NULL,
-  `updated_at` datetime DEFAULT NULL,
-  PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
-
+-- Table structure for table `classifieds`
+--
 
 DROP TABLE IF EXISTS `classifieds`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `classifieds` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `title` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
@@ -26,31 +36,36 @@ CREATE TABLE `classifieds` (
   `item_img_file_size` int(11) DEFAULT NULL,
   `item_img_updated_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`),
+  UNIQUE KEY `arbitrary_index_name` (`employee_id`, `classified_type_id`) USING BTREE,
   KEY `index_classifieds_on_employee_id` (`employee_id`),
-  KEY `index_classifieds_on_classified_type_id` (`classified_type_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+  KEY `index_classifieds_on_classified_type_id` (`classified_type_id`) USING BTREE
+) ENGINE=NDB AUTO_INCREMENT=9 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
 
+--
+-- Table structure for table `schema_migrations`
+--
 
 DROP TABLE IF EXISTS `schema_migrations`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `schema_migrations` (
   `version` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
   UNIQUE KEY `unique_schema_migrations` (`version`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
+/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
+/*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
+/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
-DROP TABLE IF EXISTS `teams`;
-CREATE TABLE `teams` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
-  `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `created_at` datetime NOT NULL,
-  `updated_at` datetime NOT NULL,
-  `email` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `description` text COLLATE utf8_unicode_ci,
-  PRIMARY KEY (`id`),
-  KEY `index_teams_on_name` (`name`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
-
-
+-- Dump completed on 2016-06-02 13:55:23
 INSERT INTO schema_migrations (version) VALUES ('20150213221911');
 
 INSERT INTO schema_migrations (version) VALUES ('20150213222926');
@@ -94,3 +109,4 @@ INSERT INTO schema_migrations (version) VALUES ('20150612181455');
 INSERT INTO schema_migrations (version) VALUES ('20150612232043');
 
 INSERT INTO schema_migrations (version) VALUES ('20160424213633');
+


### PR DESCRIPTION
Sorts index declarations and strips "USING BTREE", as it is the default
for innodb and myisam tables. Technically breaks the other two engines;
consider lookahead that checks the last line of the table definition as
a future improvement.