### PR TITLE
Adds option to sort schema migration versions

### DIFF
--- a/spec/activerecord/mysql/structure_spec.rb
+++ b/spec/activerecord/mysql/structure_spec.rb
@@ -25,7 +25,8 @@ describe ActiveRecord::Mysql::Structure do
           ActiveRecordMySqlStructure::StructureSqlSanitizer.new(
             filename,
             sorted_columns: true,
-            sorted_indices: false
+            sorted_indices: false,
+            sorted_schema_versions: false,
           )
         end
 
@@ -41,7 +42,8 @@ describe ActiveRecord::Mysql::Structure do
           ActiveRecordMySqlStructure::StructureSqlSanitizer.new(
             filename,
             sorted_columns: false,
-            sorted_indices: true
+            sorted_indices: true,
+            sorted_schema_versions: false,
           )
         end
 
@@ -67,6 +69,23 @@ describe ActiveRecord::Mysql::Structure do
               subject.sanitize!
             end.to raise_error(RuntimeError)
           end
+        end
+      end
+
+      context 'with sorted schema versions enabled' do
+        subject do
+          ActiveRecordMySqlStructure::StructureSqlSanitizer.new(
+            filename,
+            sorted_columns: false,
+            sorted_indices: false,
+            sorted_schema_versions: true,
+          )
+        end
+        let(:filename) { File.join(RSpec::root, 'data', 'structure.modern-versions-dump.sql') }
+        let(:expected_filename) { File.join(RSpec.root, %w[data structure.modern-versions-dump-expected.sql]) }
+
+        it 'sorts and sanitizes the versions' do
+          expect(subject.sanitize!).to eq(expected_sanitized_content)
         end
       end
     end

--- a/spec/data/structure.modern-versions-dump-expected.sql
+++ b/spec/data/structure.modern-versions-dump-expected.sql
@@ -1,0 +1,77 @@
+-- MySQL Dump modified by gem 'activerecord-mysql-structure'
+
+
+DROP TABLE IF EXISTS `classified_types`;
+CREATE TABLE `classified_types` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `created_at` datetime DEFAULT NULL,
+  `updated_at` datetime DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+
+
+DROP TABLE IF EXISTS `classifieds`;
+CREATE TABLE `classifieds` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `title` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `content` text COLLATE utf8_unicode_ci,
+  `dollars` int(11) DEFAULT NULL,
+  `employee_id` int(11) DEFAULT NULL,
+  `classified_type_id` int(11) DEFAULT NULL,
+  `created_at` datetime DEFAULT NULL,
+  `updated_at` datetime DEFAULT NULL,
+  `item_img_file_name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `item_img_content_type` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `item_img_file_size` int(11) DEFAULT NULL,
+  `item_img_updated_at` datetime DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `index_classifieds_on_employee_id` (`employee_id`),
+  KEY `index_classifieds_on_classified_type_id` (`classified_type_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+
+
+DROP TABLE IF EXISTS `schema_migrations`;
+CREATE TABLE `schema_migrations` (
+  `version` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
+  UNIQUE KEY `unique_schema_migrations` (`version`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+
+
+DROP TABLE IF EXISTS `teams`;
+CREATE TABLE `teams` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `created_at` datetime NOT NULL,
+  `updated_at` datetime NOT NULL,
+  `email` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `description` text COLLATE utf8_unicode_ci,
+  PRIMARY KEY (`id`),
+  KEY `index_teams_on_name` (`name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+
+
+INSERT INTO `schema_migrations` (version) VALUES
+('20150213221911'),
+('20150213222926'),
+('20150213225251'),
+('20150213230121'),
+('20150213232012'),
+('20150214000513'),
+('20150214004737'),
+('20150214005057'),
+('20150214011626'),
+('20150214013535'),
+('20150214084227'),
+('20150216213539'),
+('20150315230851'),
+('20150315230955'),
+('20150319154456'),
+('20150411191006'),
+('20150417172914'),
+('20150418072605'),
+('20150612174040'),
+('20150612181455'),
+('20150612232043'),
+('20160422080533'),
+('20160424213633');

--- a/spec/data/structure.modern-versions-dump.sql
+++ b/spec/data/structure.modern-versions-dump.sql
@@ -1,0 +1,126 @@
+-- MySQL dump 10.13  Distrib 5.5.44, for osx10.11 (x86_64)
+--
+-- Host: localhost    Database: development
+-- ------------------------------------------------------
+-- Server version 5.5.44
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!40101 SET NAMES utf8mb4 */;
+/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+/*!40103 SET TIME_ZONE='+00:00' */;
+/*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
+/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
+/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
+
+--
+-- Table structure for table `classified_types`
+--
+
+DROP TABLE IF EXISTS `classified_types`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `classified_types` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `created_at` datetime DEFAULT NULL,
+  `updated_at` datetime DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `classifieds`
+--
+
+DROP TABLE IF EXISTS `classifieds`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `classifieds` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `title` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `content` text COLLATE utf8_unicode_ci,
+  `dollars` int(11) DEFAULT NULL,
+  `employee_id` int(11) DEFAULT NULL,
+  `classified_type_id` int(11) DEFAULT NULL,
+  `created_at` datetime DEFAULT NULL,
+  `updated_at` datetime DEFAULT NULL,
+  `item_img_file_name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `item_img_content_type` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `item_img_file_size` int(11) DEFAULT NULL,
+  `item_img_updated_at` datetime DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `index_classifieds_on_employee_id` (`employee_id`),
+  KEY `index_classifieds_on_classified_type_id` (`classified_type_id`)
+) ENGINE=InnoDB AUTO_INCREMENT=9 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `schema_migrations`
+--
+
+DROP TABLE IF EXISTS `schema_migrations`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `schema_migrations` (
+  `version` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
+  UNIQUE KEY `unique_schema_migrations` (`version`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `teams`
+--
+
+DROP TABLE IF EXISTS `teams`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `teams` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `created_at` datetime NOT NULL,
+  `updated_at` datetime NOT NULL,
+  `email` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `description` text COLLATE utf8_unicode_ci,
+  PRIMARY KEY (`id`),
+  KEY `index_teams_on_name` (`name`)
+) ENGINE=InnoDB AUTO_INCREMENT=17 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
+
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
+/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
+/*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
+/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
+
+-- Dump completed on 2016-06-02 13:55:23
+INSERT INTO `schema_migrations` (version) VALUES
+('20150213221911'),
+('20150213222926'),
+('20150213225251'),
+('20150213230121'),
+('20150213232012'),
+('20150214000513'),
+('20150214004737'),
+('20150214005057'),
+('20150214011626'),
+('20150214013535'),
+('20150214084227'),
+('20150216213539'),
+('20150315230851'),
+('20150315230955'),
+('20150319154456'),
+('20150411191006'),
+('20150417172914'),
+('20150612174040'),
+('20150418072605'),
+('20150612181455'),
+('20150612232043'),
+('20160424213633'),
+('20160422080533');
+


### PR DESCRIPTION
If migrations are run out of order on a given machine, migration versions thrash. Sort them out. 